### PR TITLE
add vuln scanner & auto exploit tool - vMass Bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Information Gathering tools allows you to collect host metadata about services a
 | ----------- |-------------------------|----------|----------------|
 | [theHarvester](https://github.com/laramies/theHarvester)      | **Python** | `Linux/Windows/macOS` | E-mails, subdomains and names Harvester. |
 | [CTFR](https://github.com/UnaPibaGeek/ctfr)      | **Python** | `Linux/Windows/macOS` | Abusing Certificate Transparency logs for getting HTTPS websites subdomains. |
-| [Sn1per](https://github.com/1N3/Sn1per)      | **bash** | `Linux/macOS` | Automated Pentest Recon Scanner. |
+| [Sn1per](https://github.com/1N3/Sn1per)      | **bash** | `Linux/macOS` | Automated Pentest Recon Scanner. |<
 | [RED Hawk](https://github.com/Tuhinshubhra/RED_HAWK)      | **PHP** | `Linux/Windows/macOS` | All in one tool for Information Gathering, Vulnerability Scanning and Crawling. A must have tool for all penetration testers. |
 | [Infoga](https://github.com/m4ll0k/Infoga)      | **Python** | `Linux/Windows/macOS` | Email Information Gathering. |
 | [KnockMail](https://github.com/4w4k3/KnockMail)      | **Python** | `Linux/Windows/macOS` | Check if email address exists. |
@@ -226,6 +226,7 @@ Exploit popular CMSs that are hosted online.
 | [Joomscan](https://github.com/rezasp/joomscan)      | **Perl** | `Linux/Windows/macOS` | Joomla Vulnerability Scanner. |
 | [Drupwn](https://github.com/immunIT/drupwn)      | **Python** | `Linux/Windows/macOS` | Drupal Security Scanner to perform enumerations on Drupal-based web applications. |
 | [CMSeek](https://github.com/Tuhinshubhra/CMSeek)      | **Python** | `Linux/Windows/macOS` | CMS Detection and Exploitation suite - Scan WordPress, Joomla, Drupal and 130 other CMSs. |
+| [vMass Bot](https://github.com/c99tn/vMass)      | **Perl** | `Linux/Windows/macOS` | Vulnerability Scanner & Auto Exploiter Tool. |
 
 #### :tada: Post Exploitation
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Information Gathering tools allows you to collect host metadata about services a
 | ----------- |-------------------------|----------|----------------|
 | [theHarvester](https://github.com/laramies/theHarvester)      | **Python** | `Linux/Windows/macOS` | E-mails, subdomains and names Harvester. |
 | [CTFR](https://github.com/UnaPibaGeek/ctfr)      | **Python** | `Linux/Windows/macOS` | Abusing Certificate Transparency logs for getting HTTPS websites subdomains. |
-| [Sn1per](https://github.com/1N3/Sn1per)      | **bash** | `Linux/macOS` | Automated Pentest Recon Scanner. |<
+| [Sn1per](https://github.com/1N3/Sn1per)      | **bash** | `Linux/macOS` | Automated Pentest Recon Scanner. |
 | [RED Hawk](https://github.com/Tuhinshubhra/RED_HAWK)      | **PHP** | `Linux/Windows/macOS` | All in one tool for Information Gathering, Vulnerability Scanning and Crawling. A must have tool for all penetration testers. |
 | [Infoga](https://github.com/m4ll0k/Infoga)      | **Python** | `Linux/Windows/macOS` | Email Information Gathering. |
 | [KnockMail](https://github.com/4w4k3/KnockMail)      | **Python** | `Linux/Windows/macOS` | Check if email address exists. |


### PR DESCRIPTION
Content Update : Yes

Related Content : Web Hacking

Name: vMass Bot

Type:Vulnerability Scanner & Auto Exploiter Tool - Web Hacking

Description: vMass Bot automates the exploitation of remote hosts by trying to find environment files (.env) in target hosts and extract tools and info insde, then the bot detects the target host CMS and tries to auto exploit and upload shell payload.

Github: https://github.com/c99tn/vMass

Content Update : Yes|No

Related Content : Guide|Tools

**Content Update :** Yes|No

**Related Content :** Guide|Tools

*Explain your changes here. Please read CONTRIBUTING.md before creating pull requests.*
